### PR TITLE
Add Go modules supported.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,40 @@
+module github.com/knative-sample/serving-controller
+
+go 1.13
+
+require (
+	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
+	contrib.go.opencensus.io/exporter/stackdriver v0.12.2 // indirect
+	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
+	github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/google/go-containerregistry v0.0.0-20190619182234-abf9ef06abd9 // indirect
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3 // indirect
+	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/onsi/ginkgo v1.10.2 // indirect
+	github.com/onsi/gomega v1.7.0 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/spf13/cobra v0.0.5
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
+	go.uber.org/zap v1.9.2-0.20180814183419-67bc79d13d15
+	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/api v0.0.0-20190528110122-9ad12a4af326
+	k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc
+	k8s.io/client-go v0.0.0-20190528110200-4f3abb12cae2
+	k8s.io/kube-openapi v0.0.0-20180711000925-0cf8f7e6ed1d // indirect
+	knative.dev/caching v0.0.0-20190801030343-6e4e72a5e3a8 // indirect
+	knative.dev/pkg v0.0.0-20190801223944-2b848f71969c
+	knative.dev/serving v0.8.0
+)


### PR DESCRIPTION
No go.sum because of the dependence version specified in go.mod from Gopkg.lock